### PR TITLE
Place struct header in include dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,15 @@ jobs:
           echo "TAG_NAME=${{ needs.setup.outputs.tag_name }}" >> $GITHUB_ENV
           cd $GITHUB_WORKSPACE/..
           echo "PARENT_DIR=$PWD" >> $GITHUB_ENV
-          if [[ ${{ matrix.root }} == "with-root" ]]; then export DISABLE_ROOT="OFF"; else export DISABLE_ROOT="ON"; fi
+          export ROOT_VERSION=$(root-config --version | sed "s/\./\-/g")
+          if [[ ${{ matrix.root }} == "with-root" ]]; then
+            export DISABLE_ROOT="OFF"
+            export ROOT_TAG="root-${ROOT_VERSION}"
+          else 
+            export DISABLE_ROOT="ON"
+            export ROOT_TAG="no-root"
+          fi
+          echo "ROOT_TAG=${ROOT_TAG}" >> $GITHUB_ENV
           echo "DISABLE_ROOT=${DISABLE_ROOT}" >> $GITHUB_ENV
       - name: install miniconda
         run: |
@@ -83,12 +91,12 @@ jobs:
           cmake --preset ${{ matrix.preset}} -DCMAKE_INSTALL_PREFIX=${PARENT_DIR}/srs-install -DNO_ROOT=$DISABLE_ROOT
           cmake --build ./build --target install -- -j2
           cd ${{ env.PARENT_DIR }}
-          tar czf "srs-${{ matrix.os}}-x86-64-${{ env.TAG_NAME }}-${{ matrix.root }}.tar.gz" srs-install
+          tar czf "srs-${{ matrix.os}}-x86-64-${{ env.TAG_NAME }}-${{ env.ROOT_TAG }}.tar.gz" srs-install
 
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os}}-${{ env.TAG_NAME }}-${{ matrix.root }}
-          path: ${{ env.PARENT_DIR }}/srs-${{ matrix.os}}-x86-64-${{ env.TAG_NAME }}-${{ matrix.root }}.tar.gz
+          path: ${{ env.PARENT_DIR }}/srs-${{ matrix.os}}-x86-64-${{ env.TAG_NAME }}-${{ env.ROOT_TAG }}.tar.gz
           retention-days: 1
 
   publish-release:

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -38,7 +38,13 @@ endif()
 add_subdirectory(srs)
 
 add_executable(srs_control main.cpp)
-target_link_libraries(srs_control PRIVATE srscpp spdlog::spdlog CLI11::CLI11 Boost::thread)
+target_link_libraries(
+    srs_control
+    PRIVATE srscpp
+            spdlog::spdlog
+            CLI11::CLI11
+            Boost::thread
+            srs_data)
 target_compile_definitions(srs_control PUBLIC SRS_PROJECT_VERSION="v${CMAKE_PROJECT_VERSION}")
 
 include(${CMAKE_SOURCE_DIR}/cmake/install_targets.cmake)

--- a/backend/main.cpp
+++ b/backend/main.cpp
@@ -1,8 +1,12 @@
 #include "CLIOptionsMap.hpp"
 #include <CLI/CLI.hpp>
+#include <print>
 #include <spdlog/spdlog.h>
 #include <srs/Application.hpp>
-#include <print>
+
+#ifdef HAS_ROOT
+#include <TROOT.h>
+#endif
 
 auto main(int argc, char** argv) -> int
 {
@@ -15,8 +19,10 @@ auto main(int argc, char** argv) -> int
         auto print_mode = srs::DataPrintMode::print_speed;
         auto output_filenames = std::vector<std::string>{ "output.bin" };
         auto is_version_print = false;
+        auto is_root_version_print = false;
 
         cli_args.add_flag("-v, --version", is_version_print, "show the current version");
+        cli_args.add_flag("--root-version", is_root_version_print, "show the ROOT version if used");
         cli_args.add_option("-l, --log-level", spdlog_level, "set log level")
             ->transform(CLI::CheckedTransformer(spd_log_map, CLI::ignore_case))
             ->capture_default_str();
@@ -28,9 +34,19 @@ auto main(int argc, char** argv) -> int
             ->expected(0, -1);
         cli_args.parse(argc, argv);
 
-        if(is_version_print)
+        if (is_version_print)
         {
             std::println("{}", SRS_PROJECT_VERSION);
+            return 0;
+        }
+
+        if (is_root_version_print)
+        {
+#ifdef HAS_ROOT
+            std::println("{}", gROOT->GetVersion());
+#else
+            std::println("ROOT is not built");
+#endif
             return 0;
         }
 

--- a/backend/srs/analysis/DataProcessManager.hpp
+++ b/backend/srs/analysis/DataProcessManager.hpp
@@ -9,7 +9,7 @@
 #include <srs/converters/SerializableBuffer.hpp>
 #include <srs/converters/StructDeserializer.hpp>
 #include <srs/converters/StructToProtoConverter.hpp>
-#include <srs/data/DataStructs.hpp>
+#include <srs/data/SRSDataStructs.hpp>
 #include <srs/utils/ValidData.hpp>
 #include <srs/writers/DataWriter.hpp>
 #include <tbb/concurrent_queue.h>

--- a/backend/srs/analysis/DataProcessor.cpp
+++ b/backend/srs/analysis/DataProcessor.cpp
@@ -8,7 +8,7 @@
 #include <spdlog/spdlog.h>
 #include <srs/Application.hpp>
 #include <srs/analysis/DataProcessor.hpp>
-#include <srs/data/DataStructs.hpp>
+#include <srs/data/SRSDataStructs.hpp>
 #include <srs/data/DataStructsFormat.hpp>
 
 namespace srs

--- a/backend/srs/analysis/DataProcessor.hpp
+++ b/backend/srs/analysis/DataProcessor.hpp
@@ -10,7 +10,7 @@
 #include <srs/analysis/DataProcessManager.hpp>
 #include <srs/converters/SerializableBuffer.hpp>
 #include <srs/converters/StructDeserializer.hpp>
-#include <srs/data/DataStructs.hpp>
+#include <srs/data/SRSDataStructs.hpp>
 #include <srs/writers/DataWriter.hpp>
 #include <tbb/concurrent_queue.h>
 

--- a/backend/srs/converters/ProtoToStructConverter.hpp
+++ b/backend/srs/converters/ProtoToStructConverter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <srs/data/DataStructs.hpp>
+#include <srs/data/SRSDataStructs.hpp>
 #include <srs/data/message.pb.h>
 
 namespace srs

--- a/backend/srs/converters/StructDeserializer.hpp
+++ b/backend/srs/converters/StructDeserializer.hpp
@@ -4,7 +4,7 @@
 #include <spdlog/spdlog.h>
 #include <srs/Application.hpp>
 #include <srs/converters/DataConverterBase.hpp>
-#include <srs/data/DataStructs.hpp>
+#include <srs/data/SRSDataStructs.hpp>
 #include <srs/utils/CommonFunctions.hpp>
 #include <srs/utils/CommonAlias.hpp>
 

--- a/backend/srs/data/CMakeLists.txt
+++ b/backend/srs/data/CMakeLists.txt
@@ -13,11 +13,11 @@ target_sources(
            ${CMAKE_SOURCE_DIR}/backend
            ${CMAKE_BINARY_DIR}/backend
            FILES
-           DataStructs.hpp
+           SRSDataStructs.hpp
            DataStructsFormat.hpp
            ${CMAKE_CURRENT_BINARY_DIR}/message.pb.h)
 
-target_sources(srscpp PUBLIC FILE_SET publicHeaders FILES DataStructs.hpp)
+target_sources(srscpp PUBLIC FILE_SET publicHeaders FILES SRSDataStructs.hpp)
 
 protobuf_generate(
     TARGET
@@ -41,9 +41,11 @@ if(ROOT_FOUND)
     target_link_libraries(srs_data PUBLIC ROOT::RIO ROOT::Tree)
     target_compile_definitions(srs_data PUBLIC HAS_ROOT=1)
     target_compile_options(srs_data PUBLIC "-Wno-cpp")
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/SRSDataStructs.hpp
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     root_generate_dictionary(
         srs_dict
-        DataStructs.hpp
+        SRSDataStructs.hpp
         MODULE
         srs_data
         LINKDEF

--- a/backend/srs/data/DataStructsFormat.hpp
+++ b/backend/srs/data/DataStructsFormat.hpp
@@ -1,6 +1,6 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
-#include <srs/data/DataStructs.hpp>
+#include <srs/data/SRSDataStructs.hpp>
 
 template <>
 class fmt::formatter<srs::ReceiveDataHeader>

--- a/backend/srs/data/SRSDataStructs.hpp
+++ b/backend/srs/data/SRSDataStructs.hpp
@@ -62,4 +62,5 @@ namespace srs
         struct_data.marker_data.clear();
         struct_data.hit_data.clear();
     }
+
 } // namespace srs

--- a/backend/srs/data/SRSLinkDef.hpp
+++ b/backend/srs/data/SRSLinkDef.hpp
@@ -1,8 +1,4 @@
-#ifdef __CINT__
-
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+#ifdef __CLING__
 
 #pragma link C++ class srs::ReceiveDataHeader+;
 #pragma link C++ class srs::MarkerData+;

--- a/backend/srs/readers/ProtoMsgReader.hpp
+++ b/backend/srs/readers/ProtoMsgReader.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <memory>
-#include <srs/data/DataStructs.hpp>
+#include <srs/data/SRSDataStructs.hpp>
 #include <string_view>
 
 namespace srs

--- a/backend/srs/srs.hpp
+++ b/backend/srs/srs.hpp
@@ -1,4 +1,4 @@
 #pragma once
 
-#include <srs/data/DataStructs.hpp>
+#include <srs/data/SRSDataStructs.hpp>
 #include <srs/readers/ProtoMsgReader.hpp>

--- a/backend/srs/writers/DataWriter.hpp
+++ b/backend/srs/writers/DataWriter.hpp
@@ -3,7 +3,7 @@
 #include <boost/thread/future.hpp>
 #include <map>
 #include <srs/converters/DataConvertOptions.hpp>
-#include <srs/data/DataStructs.hpp>
+#include <srs/data/SRSDataStructs.hpp>
 #include <srs/writers/DataWriterOptions.hpp>
 
 namespace srs

--- a/backend/srs/writers/JsonWriter.hpp
+++ b/backend/srs/writers/JsonWriter.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <srs/data/DataStructs.hpp>
 #include <fstream>
 #include <glaze/glaze.hpp>
 #include <map>
 #include <spdlog/spdlog.h>
 #include <srs/analysis/DataProcessManager.hpp>
+#include <srs/data/SRSDataStructs.hpp>
 
 namespace srs
 {
@@ -92,10 +92,7 @@ namespace srs
             coro_sync_start(coro_, std::optional<InputType>{}, asio::use_awaitable);
         }
 
-        [[nodiscard]] static auto get_convert_mode() -> DataConvertOptions
-        {
-            return DataConvertOptions::structure;
-        }
+        [[nodiscard]] static auto get_convert_mode() -> DataConvertOptions { return DataConvertOptions::structure; }
 
         auto write(auto fut) -> boost::unique_future<std::optional<int>> { return {}; }
 

--- a/backend/srs/writers/RootFileWriter.hpp
+++ b/backend/srs/writers/RootFileWriter.hpp
@@ -2,9 +2,10 @@
 
 #ifdef HAS_ROOT
 #include <TFile.h>
+#include <TSystem.h>
 #include <TTree.h>
 #include <srs/analysis/DataProcessManager.hpp>
-#include <srs/data/DataStructs.hpp>
+#include <srs/data/SRSDataStructs.hpp>
 
 namespace srs
 {
@@ -25,6 +26,8 @@ namespace srs
             tree.Branch("srs_frame_data", &output_buffer_);
             coro_ = generate_coro(thread_pool.get_executor());
             coro_sync_start(coro_, std::optional<InputType>{}, asio::use_awaitable);
+            spdlog::trace("ROOT INCLUDE DIRS: {}", gSystem->GetIncludePath());
+            spdlog::trace("ROOT LIBRARIES: {}", gSystem->GetLibraries());
         }
 
         auto write(auto pre_future) -> OutputFuture { return create_coro_future(coro_, pre_future); }


### PR DESCRIPTION
ROOT requires the header to be in the include dir such that CLING can correctly interpret the data